### PR TITLE
Remove table of contents block

### DIFF
--- a/pup_food_experts_index.html
+++ b/pup_food_experts_index.html
@@ -91,20 +91,6 @@
       </div>
     </div>
   </section>
-
-  <!-- Table of contents -->
-  <section class="mx-auto max-w-6xl px-4">
-    <div class="bg-white border border-slate-200 rounded-2xl p-4 md:p-6 shadow-sm">
-      <h2 class="text-lg font-semibold mb-3">Contents</h2>
-      <ol class="grid md:grid-cols-3 gap-2 text-sm list-decimal list-inside">
-        <li><a class="text-[var(--brand)] hover:underline" href="#rankings">Top dog food delivery services</a></li>
-        <li><a class="text-[var(--brand)] hover:underline" href="#compare">Side‑by‑side comparison</a></li>
-        <li><a class="text-[var(--brand)] hover:underline" href="#howwepick">How we choose</a></li>
-        <li><a class="text-[var(--brand)] hover:underline" href="#faq">FAQ</a></li>
-      </ol>
-    </div>
-  </section>
-
   <!-- Rankings -->
   <section id="rankings" class="mx-auto max-w-6xl px-4 mt-10 space-y-6">
     <!-- Card template notes: Replace href="#" with your affiliate links. Replace placeholders with your own copy. -->


### PR DESCRIPTION
## Summary
- remove obsolete table of contents section so that rankings appear immediately after the hero

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acc99924b0832c84b37af40d0b3c2e